### PR TITLE
Add a formatter for gml

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,19 @@
                 "path": "./syntaxes/serenity-ipc.tmLanguage.json"
             }
         ]
+    },
+    "activationEvents": [
+        "onLanguage:serenity-gml"
+    ],
+    "main": "./out/extension.js",
+    "scripts": {
+        "vscode:prepublish": "npm run compile",
+        "compile": "tsc -p ./",
+        "watch": "tsc -watch -p ./"
+    },
+    "devDependencies": {
+        "@types/node": "14.x",
+        "@types/vscode": "^1.58.0",
+        "typescript": "^4.5.4"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,35 @@
+'use strict';
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import {spawnSync} from 'child_process';
+
+export function activate(context: vscode.ExtensionContext) {
+  vscode.languages.registerDocumentFormattingEditProvider('serenity-gml', {
+    provideDocumentFormattingEdits(document: vscode.TextDocument) {
+      // FIXME: gml-format does not support files over stdin, yet,
+      //        so we have to force-save it for now
+      // FIXME: Allow partial re-formatting
+      document.save();
+      let filename = document.fileName;
+      let rootPath = vscode.workspace.rootPath;
+      let eof = document.positionAt(document.getText().length);
+
+      let executablePath = rootPath + '/Build/lagom/gml-format'
+
+      if (!fs.existsSync(executablePath)) {
+        vscode.window.showErrorMessage(
+            'Could not find gml-format. Please build lagom first.');
+        return [];
+      }
+
+      let childOutput = spawnSync(executablePath, ['-i', filename]);
+      if (childOutput.status != 0) {
+        vscode.window.showErrorMessage(
+            `gml-format failed with exit-code: ${childOutput.status}`,
+            childOutput.stderr.toString());
+      }
+
+      return [];
+    }
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "ES2020",
+		"outDir": "out",
+		"lib": [
+			"ES2020"
+		],
+		"sourceMap": true,
+		"rootDir": "src",
+		"strict": true   /* enable all strict type-checking options */
+		/* Additional Checks */
+		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
+	}
+}


### PR DESCRIPTION
This uses the gml-format executable from lagom, which is expected to
always exist when working on serenity

~~I included the generated files for now, in the future these should be generated by CI before publishing.|~~