### PR TITLE
WebIDL grammar: support multiline typedefs

### DIFF
--- a/syntaxes/serenity-web-idl.tmLanguage.json
+++ b/syntaxes/serenity-web-idl.tmLanguage.json
@@ -317,25 +317,47 @@
     },
     "typedef": {
       "name": "meta.definition.typedef.idl",
-      "match": "\\b(typedef)\\s+(.*)\\s+([_-]?[A-Za-z][0-9A-Z_a-z-]*)(;)",
-      "captures": {
+      "begin": "\\b(typedef)\\s+",
+      "end":"\\s+([_-]?[A-Za-z][0-9A-Z_a-z-]*)(;)",
+      "beginCaptures": {
         "1": {
           "name": "keyword.other.typedef.idl"
+        }
+      },
+      "endCaptures":{
+        "1": {
+          "name": "entity.name.type.typedef.idl"
         },
         "2": {
+          "name": "punctuation.terminator.idl"
+        }
+      },
+      "patterns": [
+          {
+          "begin": "(?=\\()",
+          "end": "(?<=\\))", 
           "patterns": [
+            {
+              "include": "#comment"
+            },
+            {
+              "name": "meta.definition.typedef.idl.multi-line",
+              "match": "\\s+(or)\\s+",
+              "captures": {
+                "1": { 
+                  "name": "keyword.control.or.idl"
+                }
+              }
+            },
             {
               "include": "#type-with-extended-attributes"
             }
           ]
         },
-        "3": {
-          "name": "entity.name.type.typedef.idl"
-        },
-        "4": {
-          "name": "punctuation.terminator.idl"
+        {
+          "include": "#type-with-extended-attributes"
         }
-      }
+      ]
     },
     "includes-statement": {
       "name": "meta.include-statement",


### PR DESCRIPTION
This adds support for multiline types in WebIDL grammars.

It is used in e.g. [CanvasDrawImage.idl:7](https://github.com/LadybirdBrowser/ladybird/blob/master/Userland/Libraries/LibWeb/HTML/Canvas/CanvasDrawImage.idl#L7)


Before:
![image](https://github.com/user-attachments/assets/a1572e52-8ebb-4707-8141-d7de30cea823)

After:
![image](https://github.com/user-attachments/assets/f74e0509-fa18-4ac3-b211-d22ded1a5a9e)
