### PR TITLE
Update gml-format path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ out/
 
 # Even though we're a binary package, it doesn't matter right now to have fixed versions.
 package-lock.json
+
+# macOS metadata
+.DS_Store

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ export function activate(context: vscode.ExtensionContext) {
       fs.writeSync(tmpFile.fd, fileContent);
       fs.closeSync(tmpFile.fd);
 
-      let executablePath = rootPath + '/Build/lagom/gml-format'
+      let executablePath = rootPath + '/Build/lagom/bin/gml-format'
 
       if (!fs.existsSync(executablePath)) {
         vscode.window.showErrorMessage(


### PR DESCRIPTION
The `gml-format` command has been moved to `Build/lagom/bin` since https://github.com/serenityOS/serenity/commit/71b184accf5e94e24cdd9cba23f70a62cd5852e6